### PR TITLE
Both the Unity and Unreal SDKs are past v1.0.0. 

### DIFF
--- a/docs/pages/sdk/unity/overview.mdx
+++ b/docs/pages/sdk/unity/overview.mdx
@@ -7,7 +7,7 @@ description: Documentation for Unity SDK overview for the Sequence infrastructur
 
 The Sequence Unity Embedded Wallet SDK provides full Sequence [Embedded Wallet](/solutions/wallets/embedded-wallet/overview) and [Indexer](/api/indexer/overview) integration for your Unity Games, integrated with our own purpose-built for Unity SequenceEthereum library. That's right, no Nethereum required!
 
-This SDK follows [Semantic Versioning](https://semver.org/) (`major.minor.patch`). While we're still in `0.x.y` builds, API breaking changes can be made at any time. After `1.0.0`, breaking changes will always cause a `major` version increment, non-breaking new features will cause a `minor` version increment, and bugfixes will cause a `patch` version increment.
+This SDK follows [Semantic Versioning](https://semver.org/) (`major.minor.patch`). Breaking changes will always cause a `major` version increment, non-breaking new features will cause a `minor` version increment, and bugfixes will cause a `patch` version increment.
 
 ## Requirements
 Unity 2021.3.6f1 or later

--- a/docs/pages/sdk/unreal/overview.mdx
+++ b/docs/pages/sdk/unreal/overview.mdx
@@ -7,7 +7,7 @@ description: Documentation for Unreal SDK overview for the Sequence infrastructu
 
 The Sequence Unreal Embedded Wallet SDK provides full Sequence [Embedded Wallet](/solutions/wallets/embedded-wallet/overview) and [Indexer](/api/indexer/overview) integration for games built on the Unreal Framework.
 
-This SDK follows [Semantic Versioning](https://semver.org/) (`major.minor.patch`). While we're still in `0.x.y` builds, API breaking changes can be made at any time. After `1.0.0`, breaking changes will always cause a `major` version increment, non-breaking new features will cause a `minor` version increment, and bugfixes will cause a `patch` version increment.
+This SDK follows [Semantic Versioning](https://semver.org/) (`major.minor.patch`). Breaking changes will always cause a `major` version increment, non-breaking new features will cause a `minor` version increment, and bugfixes will cause a `patch` version increment.
 
 Latest Sequence Unreal SDK [releases can be found here](https://github.com/0xsequence/sequence-unreal/releases).
 


### PR DESCRIPTION
Update semantic versioning callout accordingly