### PR TITLE
Remove Unused Duplicate Metadata

### DIFF
--- a/docs/pages/solutions/wallets/universal-wallet/examples/send-erc20.mdx
+++ b/docs/pages/solutions/wallets/universal-wallet/examples/send-erc20.mdx
@@ -59,11 +59,6 @@ const txnResponse = await signer.sendTransaction([transaction1, transaction2])
 console.log(txnResponse)
 
 ```
-description: Sequence is a Web3 gaming platform that allows users to send ERC-20 tokens easily using a universal wallet. With a simple code snippet, users can send a single ERC-20 token transfer to a recipient. Additionally, users can batch multiple token transfers into a single transaction f
----
----
-title: Sequence - Web3 Gaming Platform - Universal Wallet Send ERC20s
----
 
 # Sending ERC-20 Tokens
 


### PR DESCRIPTION
I was weird those to be there. The page already has title and description metadata at the beginning of the file. 
[The current page here](https://docs.sequence.xyz/solutions/wallets/universal-wallet/examples/send-erc20/#description-sequence-is-a-web3-gaming-platform-that-allows-users-to-send-erc-20-tokens-easily-using-a-universal-wallet-with-a-simple-code-snippet-users-can-send-a-single-erc-20-token-transfer-to-a-recipient-additionally-users-can-batch-multiple-token-transfers-into-a-single-transaction-f)

Before:
<img width="1440" alt="Ekran Resmi 2024-09-03 14 58 40" src="https://github.com/user-attachments/assets/1b8bf292-a733-401b-a59a-c82f007afeb1">
