### PR TITLE
Updated unreal setup docs

### DIFF
--- a/docs/pages/sdk/unity/setup.mdx
+++ b/docs/pages/sdk/unity/setup.mdx
@@ -16,9 +16,9 @@ description: Documentation for Unity SDK setup for the Sequence infrastructure s
 
     a) `Url Scheme` - You must replace this with a string that is unique to your application. This is very important. Failure to do so will cause unexpected behaviour when signing in with social sign in and it will not work.
 
-    b) `Builder API Keys` - These are found in the [Sequence Builder](https://sequence.build/) under `Settings > API Access Keys`
+    b) `Builder API Keys` - These are found in the [Sequence Builder](https://sequence.build/) under `Settings > API Keys`
 
-    c) `WaaS Config Key` - You can get this key in [Sequence Builder](https://sequence.build/) under `Wallets > Embedded Wallet`
+    c) `WaaS Config Key` - You can get this key in [Sequence Builder](https://sequence.build/) under `Onboard > Embedded Wallet`
 
     d) `StoreSessionPrivateKeyInSecureStorage` - Available on select platforms: we have integrated with the platform's native secure storage system. If enabled, we will store session wallet info (including the private key) in secure storage and automatically attempt to recover the session for the user after closing the app (so they won't need to login again). With this disabled (default) or on an unsupported platform, the session wallet's private keys never leave the application's runtime memory; however, your user will need to sign in again anytime they close the app. The default `LoginPanel` UI (see [Recovering Sessions](/sdk/unity/recovering-sessions)) will handle this behaviour for you automatically, navigating to the appropriate page.
 

--- a/docs/pages/sdk/unreal/setup.mdx
+++ b/docs/pages/sdk/unreal/setup.mdx
@@ -5,7 +5,10 @@ description: Documentation for Unity SDK setup for the Sequence infrastructure s
 
 # Setup
 
-1. Navigate to `[YourProjectDirectory]/Config`, create a file named `SequenceConfig.ini`, and add the following lines:
+::::steps
+
+### Create a config file
+Navigate to `[YourProjectDirectory]/Config`, create a file named `SequenceConfig.ini`, and add the following lines:
 
 ```
 [/Script/Sequence.Config]
@@ -21,13 +24,16 @@ PlayFabTitleID = ""
 RedirectUrl = "https://api.sequence.app"
 ```
 
-2. Fill in `[YourProjectDirectory]/Config/SequenceConfig.ini` with the appropriate values for your project.
+### Add your project keys
+Fill in `[YourProjectDirectory]/Config/SequenceConfig.ini` with the appropriate values for your project.
 
-    a) `WaaS Config Key` - You can get this key in [Sequence Builder](https://sequence.build/) under `Onboard > Embedded Wallet`
+`WaaS Config Key` - You can get this key in [Sequence Builder](https://sequence.build/) under **Onboard > Embedded Wallet**
 
-    b) `Project Access Key` - You can get this key in [Sequence Builder](https://sequence.build/) under `Settings > API Keys`
+`Project Access Key` - You can get this key in [Sequence Builder](https://sequence.build/) under **Settings > API Keys**
 
-    c) `Fallback Encryption Key` - Create a 32-character long alphanumeric encryption key.
+`Fallback Encryption Key` - Create a 32-character long alphanumeric encryption key.
+
+::::
 
 :::tip
 Make sure to get the WaaS keys from **Production Mode**.

--- a/docs/pages/sdk/unreal/setup.mdx
+++ b/docs/pages/sdk/unreal/setup.mdx
@@ -5,13 +5,7 @@ description: Documentation for Unity SDK setup for the Sequence infrastructure s
 
 # Setup
 
-## Configuration
-
-We now are opting to use .ini files to store configurations for the plugin rather than storing them in the plugin itself. This will make integrating updates to the plugin much simpler.
-
-To do this please go to [YourProjectDirectory]/Config And create a file named [SequenceConfig.ini]
-
-Within **[SequenceConfig.ini]** add the following lines:
+1. Navigate to `[YourProjectDirectory]/Config`, create a file named `SequenceConfig.ini`, and add the following lines:
 
 ```
 [/Script/Sequence.Config]
@@ -27,15 +21,13 @@ PlayFabTitleID = ""
 RedirectUrl = "https://api.sequence.app"
 ```
 
-## Configuration Key Management
+2. Fill in `[YourProjectDirectory]/Config/SequenceConfig.ini` with the appropriate values for your project.
 
-Before you can use the Sequence Unreal SDK, you need to acquire the following configuration keys from the Sequence Builder:
+    a) `WaaS Config Key` - You can get this key in [Sequence Builder](https://sequence.build/) under `Onboard > Embedded Wallet`
 
-**WaaSConfigKey**: This key can be learned about [here](https://docs.sequence.xyz/solutions/builder/embedded-wallet)
+    b) `Project Access Key` - You can get this key in [Sequence Builder](https://sequence.build/) under `Settings > API Keys`
 
-**ProjectAccessKey**: This key can be learned about [here](https://docs.sequence.xyz/solutions/builder/getting-started#claim-an-api-access-key)
-
-You can then add these credentials in the SequenceConfig.ini file under **[YourProject]/Config/SequenceConfig.ini.**
+    c) `Fallback Encryption Key` - Create a 32-character long alphanumeric encryption key.
 
 :::tip
 Make sure to get the WaaS keys from **Production Mode**.
@@ -46,8 +38,6 @@ Don't forget to [configure your embedded wallet settings in the Builder](/soluti
 :::
 
 ## Security
-
-You must provide a 32 character encryption key in the [SequenceConfig.ini] file under [YourProject]/Config/SequenceConfig.ini under the config variable FallbackEncryptionKey.
 
 In order to prevent tampering with data you must encrypt your packaged project using Unreals packaging settings. You can refer to [these docs](https://dev.epicgames.com/documentation/en-us/unreal-engine/packaging-unreal-engine-projects?application_version=5.3) for more information.
 


### PR DESCRIPTION
Fix a consistency issue in the Unity setup docs. Make the unreal setup section more compact. 