### PR TITLE
Changed to stored credentials on unreal to simplify onboarding

### DIFF
--- a/docs/pages/sdk/unreal/api.mdx
+++ b/docs/pages/sdk/unreal/api.mdx
@@ -13,7 +13,6 @@ In order to gain access to the SequenceAPI be sure to #include `"Sequence/Sequen
    if none are found returns a TOptional<USequenceWallet*> Pointer without any set Credentials
 */
 
-//USequenceWallet::Get()
 const TOptional<USequenceWallet*> WalletOptional = USequenceWallet::Get();
 if (WalletOptional.IsSet() && WalletOptional.GetValue())
 {
@@ -30,7 +29,6 @@ or
    given Credentials
 */
 
-//USequenceWallet::Get(const FCredentials_BE& Credentials)
 const TOptional<USequenceWallet*> WalletOptional = USequenceWallet::Get(Credentials);
 if (WalletOptional.IsSet() && WalletOptional.GetValue())
 {
@@ -47,7 +45,6 @@ or
    given Credentials & ProviderUrl
 */
 
-//USequenceWallet::Get(const FCredentials_BE& Credentials,const FString& ProviderUrl);
 const TOptional<USequenceWallet*> WalletOptional = USequenceWallet::Get(Credentials,"ProviderUrl");
 if (WalletOptional.IsSet() && WalletOptional.GetValue())
 {

--- a/docs/pages/sdk/unreal/managing-session.mdx
+++ b/docs/pages/sdk/unreal/managing-session.mdx
@@ -18,8 +18,7 @@ Used to register a session (done automatically for you by `UAuthenticator`)
 	{
 		UE_LOG(LogTemp,Display,TEXT("Error Message: %s"),*Error.Message);
     };
-    const FCredentials_BE Credentials;//Replace this var with your own credentials however you choose to get them
-    const TOptional<USequenceWallet*> WalletOptional = USequenceWallet::Get(Credentials);
+    const TOptional<USequenceWallet*> WalletOptional = USequenceWallet::Get();
     if (WalletOptional.IsSet() && WalletOptional.GetValue())
     {
 	   USequenceWallet * Api = WalletOptional.GetValue();
@@ -40,8 +39,7 @@ Lists the active sessions
 	{
 		UE_LOG(LogTemp,Display,TEXT("Error Message: %s"),*Error.Message);
     };
-    const FCredentials_BE Credentials;//Replace this var with your own credentials however you choose to get them  
-    const TOptional<USequenceWallet*> WalletOptional = USequenceWallet::Get(Credentials);
+    const TOptional<USequenceWallet*> WalletOptional = USequenceWallet::Get();
     if (WalletOptional.IsSet() && WalletOptional.GetValue())
     {
 	   USequenceWallet * Api = WalletOptional.GetValue();
@@ -54,8 +52,7 @@ Lists the active sessions
 Closes the session
 
 ```cpp
-    const FCredentials_BE Credentials;//Replace this var with your own credentials however you choose to get them
-    const TOptional<USequenceWallet*> WalletOptional = USequenceWallet::Get(Credentials);
+    const TOptional<USequenceWallet*> WalletOptional = USequenceWallet::Get();
     if (WalletOptional.IsSet() && WalletOptional.GetValue())
     {
 	   USequenceWallet * Api = WalletOptional.GetValue();
@@ -68,9 +65,7 @@ Closes the session
 Gets the wallet address currently being used
 
 ```cpp
-    const FCredentials_BE Credentials;//Replace this var with your own credentials however you choose to get them
-
-    const TOptional<USequenceWallet*> WalletOptional = USequenceWallet::Get(Credentials);
+    const TOptional<USequenceWallet*> WalletOptional = USequenceWallet::Get();
     if (WalletOptional.IsSet() && WalletOptional.GetValue())
     {
 	   USequenceWallet * Api = WalletOptional.GetValue();
@@ -83,8 +78,7 @@ Gets the wallet address currently being used
 Gets the network id being used
 
 ```cpp
-    const FCredentials_BE Credentials;//Replace this var with your own credentials however you choose to get them
-    const TOptional<USequenceWallet*> WalletOptional = USequenceWallet::Get(Credentials);
+    const TOptional<USequenceWallet*> WalletOptional = USequenceWallet::Get();
     if (WalletOptional.IsSet() && WalletOptional.GetValue())
     {
        USequenceWallet * Api = WalletOptional.GetValue();
@@ -97,9 +91,7 @@ Gets the network id being used
 Used to update the stored network id
 
 ```cpp
-    const FCredentials_BE Credentials;//Replace this var with your own credentials however you choose to get them:
-    const TOptional<USequenceWallet*> WalletOptional = USequenceWallet::Get(Credentials);
-    
+    const TOptional<USequenceWallet*> WalletOptional = USequenceWallet::Get();
     if (WalletOptional.IsSet() && WalletOptional.GetValue())
     {
        USequenceWallet * Api = WalletOptional.GetValue();
@@ -108,11 +100,8 @@ Used to update the stored network id
 ```
 ## Example UpdateProviderUrl
     
-Used to update the provider url of the wallet const FCredentials_BE Credentials;//Replace this var with your own credentials however you choose to get them:
-    
 ```cpp
-    const TOptional<USequenceWallet*> WalletOptional = USequenceWallet::Get(Credentials);
-    
+    const TOptional<USequenceWallet*> WalletOptional = USequenceWallet::Get();
     if (WalletOptional.IsSet() && WalletOptional.GetValue())
     {
        USequenceWallet * Api = WalletOptional.GetValue();
@@ -124,8 +113,7 @@ Used to update the provider url of the wallet const FCredentials_BE Credentials;
 Closes the session & clears out cached credentials with blank ones
 
 ```cpp
-    const FCredentials_BE Credentials;//Replace this var with your own credentials however you choose to get them
-    const TOptional<USequenceWallet*> WalletOptional = USequenceWallet::Get(Credentials);
+    const TOptional<USequenceWallet*> WalletOptional = USequenceWallet::Get();
     if (WalletOptional.IsSet() && WalletOptional.GetValue())
     {
 	   USequenceWallet * Api = WalletOptional.GetValue();

--- a/docs/pages/sdk/unreal/onboard-user-funds.mdx
+++ b/docs/pages/sdk/unreal/onboard-user-funds.mdx
@@ -44,8 +44,7 @@ Transak->GetSupportedCountries(
 You can also access the Transak functionalities straight from `USequenceWallet`:
 
 ```cpp
-const FCredentials_BE Credentials; // Replace this var with your own credentials however you choose to get them
-const TOptional<USequenceWallet*> WalletOptional = USequenceWallet::Get(Credentials);
+const TOptional<USequenceWallet*> WalletOptional = USequenceWallet::Get();
 if (WalletOptional.IsSet() && WalletOptional.GetValue())
 {
 	USequenceWallet* Wallet = WalletOptional.GetValue();

--- a/docs/pages/sdk/unreal/read-from-blockchain.mdx
+++ b/docs/pages/sdk/unreal/read-from-blockchain.mdx
@@ -20,8 +20,7 @@ const FFailureCallback GenericFailure = [=](const FSequenceError& Error)
 {
 	//Ping failure
 };
-const FCredentials_BE Credentials;//Replace this var with your own credentials however you choose to get them
-const TOptional<USequenceWallet*> WalletOptional = USequenceWallet::Get(Credentials);
+const TOptional<USequenceWallet*> WalletOptional = USequenceWallet::Get();
 if (WalletOptional.IsSet() && WalletOptional.GetValue())
 {
 	USequenceWallet * Api = WalletOptional.GetValue();
@@ -40,8 +39,7 @@ const FFailureCallback GenericFailure = [=](const FSequenceError& Error)
 {
 	//Version Failure
 };
-const FCredentials_BE Credentials;//Replace this var with your own credentials however you choose to get them
-const TOptional<USequenceWallet*> WalletOptional = USequenceWallet::Get(Credentials);
+const TOptional<USequenceWallet*> WalletOptional = USequenceWallet::Get();
 if (WalletOptional.IsSet() && WalletOptional.GetValue())
 {
 	USequenceWallet * Api = WalletOptional.GetValue();
@@ -60,8 +58,7 @@ const FFailureCallback GenericFailure = [=](const FSequenceError& Error)
 {
 	//RunTimeStatus Failure
 };
-const FCredentials_BE Credentials;//Replace this var with your own credentials however you choose to get them
-const TOptional<USequenceWallet*> WalletOptional = USequenceWallet::Get(Credentials);
+const TOptional<USequenceWallet*> WalletOptional = USequenceWallet::Get();
 if (WalletOptional.IsSet() && WalletOptional.GetValue())
 {
 	USequenceWallet * Api = WalletOptional.GetValue();
@@ -80,8 +77,7 @@ const FFailureCallback GenericFailure = [=](const FSequenceError& Error)
 {
 	//GetChainID Failure
 };
-const FCredentials_BE Credentials;//Replace this var with your own credentials however you choose to get them
-const TOptional<USequenceWallet*> WalletOptional = USequenceWallet::Get(Credentials);
+const TOptional<USequenceWallet*> WalletOptional = USequenceWallet::Get();
 if (WalletOptional.IsSet() && WalletOptional.GetValue())
 {
 	USequenceWallet * Api = WalletOptional.GetValue();
@@ -101,8 +97,7 @@ const FFailureCallback GenericFailure = [=](const FSequenceError& Error)
 	//GetEtherBalance Failure
 };
 	
-const FCredentials_BE Credentials;//Replace this var with your own credentials however you choose to get them
-const TOptional<USequenceWallet*> WalletOptional = USequenceWallet::Get(Credentials);
+const TOptional<USequenceWallet*> WalletOptional = USequenceWallet::Get();
 if (WalletOptional.IsSet() && WalletOptional.GetValue())
 {
 	USequenceWallet * Api = WalletOptional.GetValue();
@@ -122,8 +117,7 @@ if (WalletOptional.IsSet() && WalletOptional.GetValue())
 		//GetTokenBalances Failure
 	};
    
-	const FCredentials_BE Credentials;//Replace this var with your own credentials however you choose to get them
-	const TOptional<USequenceWallet*> WalletOptional = USequenceWallet::Get(Credentials);
+	const TOptional<USequenceWallet*> WalletOptional = USequenceWallet::Get();
 	if (WalletOptional.IsSet() && WalletOptional.GetValue())
 	{
 		USequenceWallet * Api = WalletOptional.GetValue();
@@ -146,8 +140,7 @@ if (WalletOptional.IsSet() && WalletOptional.GetValue())
 		//GetTokenSupplies Failure
 	};
     
-	const FCredentials_BE Credentials;//Replace this var with your own credentials however you choose to get them
-	const TOptional<USequenceWallet*> WalletOptional = USequenceWallet::Get(Credentials);
+	const TOptional<USequenceWallet*> WalletOptional = USequenceWallet::Get();
 	if (WalletOptional.IsSet() && WalletOptional.GetValue())
 	{
 		USequenceWallet * Api = WalletOptional.GetValue();
@@ -169,8 +162,7 @@ const FFailureCallback GenericFailure = [=](const FSequenceError& Error)
 {
 	//GetTokenSuppliesMap Failure
 };
-const FCredentials_BE Credentials;//Replace this var with your own credentials however you choose to get them
-const TOptional<USequenceWallet*> WalletOptional = USequenceWallet::Get(Credentials);
+const TOptional<USequenceWallet*> WalletOptional = USequenceWallet::Get();
 if (WalletOptional.IsSet() && WalletOptional.GetValue())
 {
 	USequenceWallet * Api = WalletOptional.GetValue();    
@@ -196,8 +188,7 @@ const FFailureCallback GenericFailure = [=](const FSequenceError& Error)
 	//GetBalanceUpdates Failure
 };
 	
-const FCredentials_BE Credentials;//Replace this var with your own credentials however you choose to get them
-const TOptional<USequenceWallet*> WalletOptional = USequenceWallet::Get(Credentials);
+const TOptional<USequenceWallet*> WalletOptional = USequenceWallet::Get();
 if (WalletOptional.IsSet() && WalletOptional.GetValue())
 {
 	USequenceWallet * Api = WalletOptional.GetValue();
@@ -221,8 +212,7 @@ const FFailureCallback GenericFailure = [=](const FSequenceError& Error)
 	//GetTransactionHistory Failure
 };
    
-const FCredentials_BE Credentials;//Replace this var with your own credentials however you choose to get them
-const TOptional<USequenceWallet*> WalletOptional = USequenceWallet::Get(Credentials);
+const TOptional<USequenceWallet*> WalletOptional = USequenceWallet::Get();
 if (WalletOptional.IsSet() && WalletOptional.GetValue())
 {
 	USequenceWallet * Api = WalletOptional.GetValue();

--- a/docs/pages/sdk/unreal/write-to-blockchain.mdx
+++ b/docs/pages/sdk/unreal/write-to-blockchain.mdx
@@ -10,7 +10,7 @@ description: Documentation for Unreal SDK API for writing to the blockchain with
 Used to Sign a message
 
 ```cpp
-const TSuccessCallback<FSignedMessage> OnResponse = [this] (const FSignedMessage& Response)
+const TSuccessCallback<FSeqSignMessageResponse_Response> OnResponse = [this] (const FSeqSignMessageResponse_Response& Response)
 {
 	//Response is the signed message
 };
@@ -18,8 +18,7 @@ const FFailureCallback OnFailure = [this](const FSequenceError& Error)
 {
 	UE_LOG(LogTemp,Display,TEXT("Error Message: %s"),*Error.Message);
 };
-const FCredentials_BE Credentials;//Replace this var with your own credentials however you choose to get them
-const TOptional<USequenceWallet*> WalletOptional = USequenceWallet::Get(Credentials);
+const TOptional<USequenceWallet*> WalletOptional = USequenceWallet::Get();
 if (WalletOptional.IsSet() && WalletOptional.GetValue())
 {
    USequenceWallet* Wallet = WalletOptional.GetValue();
@@ -115,8 +114,7 @@ Txn.Push(TUnion<FRawTransaction, FERC20Transaction, FERC721Transaction, FERC1155
 
 ```cpp
 // Now send the transaction
-const FCredentials_BE Credentials; // Replace this var with your own credentials however you choose to get them
-const TOptional<USequenceWallet*> WalletOptional = USequenceWallet::Get(Credentials);
+const TOptional<USequenceWallet*> WalletOptional = USequenceWallet::Get();
 if (WalletOptional.IsSet() && WalletOptional.GetValue())
 {
 	USequenceWallet* Wallet = WalletOptional.GetValue();


### PR DESCRIPTION
It's an overhead for developers to think about where to get their credentials when most use the stored credential option.